### PR TITLE
Fix title rendering when page title missing

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="{{ page.description | default: site.description }}" />
   <meta name="author" content="{{ site.author }}" />
-  <title>{{ page.title }}{% if page.title %} — {% endif %}{{ site.title }}</title>
+  <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="stylesheet" href="{{ '/styles.css' | relative_url }}" />
   <style>


### PR DESCRIPTION
## Summary
- ensure page title is included in `<title>` only when available to avoid leading dash

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c19a2d5bc832eb2e5ed2ee2ae62ee