### PR TITLE
Make about page layout responsive

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,60 +8,62 @@ nav: about
 
 <section>
   <p>Hello, I'm Jose Flores. I work as a SharePoint Solutions Engineer and Power Platform Developer with a focus on building scalable business solutions using SPFx, Power Apps, Power Automate, and Power BI. I enjoy creating custom workflows and designing intuitive user interfaces that deliver real value to teams.</p>
-  
+
   <p>Outside of work, I'm passionate about learning new technologies, refining my development skills, and helping small businesses create a strong online presence. I also enjoy problem-solving, finding efficient workflows, and mentoring colleagues on technical tools.</p>
 </section>
 
-<section>
-  <h2>Professional Interests</h2>
-  <ul>
-    <li>Modern web development with React and TypeScript</li>
-    <li>Workflow automation and process optimization</li>
-    <li>Cloud platforms (Azure, AWS, GCP)</li>
-    <li>Small business technology solutions</li>
-  </ul>
-</section>
+<div class="about-grid">
+  <section>
+    <h2>Professional Interests</h2>
+    <ul>
+      <li>Modern web development with React and TypeScript</li>
+      <li>Workflow automation and process optimization</li>
+      <li>Cloud platforms (Azure, AWS, GCP)</li>
+      <li>Small business technology solutions</li>
+    </ul>
+  </section>
 
-<section class="parks-section">
-  <h2>National Parks I've Visited</h2>
-  <ul>
-    <li>Yosemite National Park, California</li>
-    <li>Lake Tahoe, California/Nevada</li>
-    <li>Sequoia National Park, California</li>
-    <li>Point Reyes National Seashore, California</li>
-    <li>Muir Woods National Monument, California</li>
-  </ul>
-  <p><em>Always planning the next adventure! Currently have my sights set on visiting Yellowstone and the Grand Canyon.</em></p>
-</section>
+  <section class="parks-section">
+    <h2>National Parks I've Visited</h2>
+    <ul>
+      <li>Yosemite National Park, California</li>
+      <li>Lake Tahoe, California/Nevada</li>
+      <li>Sequoia National Park, California</li>
+      <li>Point Reyes National Seashore, California</li>
+      <li>Muir Woods National Monument, California</li>
+    </ul>
+    <p><em>Always planning the next adventure! Currently have my sights set on visiting Yellowstone and the Grand Canyon.</em></p>
+  </section>
 
-<section class="movies-section">
-  <h2>Top 5 Movies</h2>
-  <ol>
-    <li>The Shawshank Redemption (1994)</li>
-    <li>Inception (2010)</li>
-    <li>The Dark Knight (2008)</li>
-    <li>Goodfellas (1990)</li>
-    <li>Pulp Fiction (1994)</li>
-  </ol>
-</section>
+  <section class="movies-section">
+    <h2>Top 5 Movies</h2>
+    <ol>
+      <li>The Shawshank Redemption (1994)</li>
+      <li>Inception (2010)</li>
+      <li>The Dark Knight (2008)</li>
+      <li>Goodfellas (1990)</li>
+      <li>Pulp Fiction (1994)</li>
+    </ol>
+  </section>
 
-<section class="music-section">
-  <h2>Top 5 Songs</h2>
-  <ol>
-    <li>"Bohemian Rhapsody" - Queen</li>
-    <li>"Hotel California" - Eagles</li>
-    <li>"Stairway to Heaven" - Led Zeppelin</li>
-    <li>"Sweet Child O' Mine" - Guns N' Roses</li>
-    <li>"Billie Jean" - Michael Jackson</li>
-  </ol>
-</section>
+  <section class="music-section">
+    <h2>Top 5 Songs</h2>
+    <ol>
+      <li>"Bohemian Rhapsody" - Queen</li>
+      <li>"Hotel California" - Eagles</li>
+      <li>"Stairway to Heaven" - Led Zeppelin</li>
+      <li>"Sweet Child O' Mine" - Guns N' Roses</li>
+      <li>"Billie Jean" - Michael Jackson</li>
+    </ol>
+  </section>
 
-<section>
-  <h2>Contact</h2>
-  <p>
-    Email: <a href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a><br />
-    Phone: <a href="tel:{{ site.contact.phone }}">{{ site.contact.phone }}</a><br />
-    LinkedIn: <a href="{{ site.contact.linkedin_url }}">linkedin.com/in/{{ site.contact.linkedin_handle }}</a><br />
-    GitHub: <a href="{{ site.contact.github_url }}">github.com/{{ site.contact.github_handle }}</a>
-  </p>
-</section>
+  <section class="contact-section">
+    <h2>Contact</h2>
+    <p>
+      Email: <a href="mailto:{{ site.contact.email }}">{{ site.contact.email }}</a><br />
+      Phone: <a href="tel:{{ site.contact.phone }}">{{ site.contact.phone }}</a><br />
+      LinkedIn: <a href="{{ site.contact.linkedin_url }}">linkedin.com/in/{{ site.contact.linkedin_handle }}</a><br />
+      GitHub: <a href="{{ site.contact.github_url }}">github.com/{{ site.contact.github_handle }}</a>
+    </p>
+  </section>
+</div>

--- a/styles.css
+++ b/styles.css
@@ -108,6 +108,22 @@ section em {
   font-style: italic;
 }
 
+/* About page layout */
+.about-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.about-grid section {
+  margin-top: 0;
+}
+
+.about-grid .contact-section {
+  grid-column: 1 / -1;
+}
+
 /* Personal sections styling - specific to about page */
 .parks-section,
 .movies-section,


### PR DESCRIPTION
## Summary
- lay out About page content in a responsive grid
- style grid to span columns on wide displays while keeping mobile-friendly stacking

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll; Install missing gem executables with `bundle install`)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden" fetching gem specs)*

------
https://chatgpt.com/codex/tasks/task_e_689c35faadb8832e961c1dd45e7f7e82